### PR TITLE
Fixed function to calculate T90

### DIFF
--- a/src/pygrb_lc/light_curves/utils.py
+++ b/src/pygrb_lc/light_curves/utils.py
@@ -46,11 +46,11 @@ def calculate_t_90(times: np.array, intergal_curve: np.array, left_interval, rig
     left_interval = left_interval if is_iterable(left_interval) else (times[0],left_interval)
     right_interval = right_interval if is_iterable(right_interval) else (right_interval,times[-1])
 
-    mask = [(times >= left_interval[0]) & (times <= left_interval[1])]
+    mask = (times >= left_interval[0]) & (times <= left_interval[1])
     level_low = np.polyfit(times[mask],intergal_curve[mask],0)[0]
     d_low = np.sqrt(np.var(intergal_curve[mask] - level_low))
 
-    mask = [(times >= right_interval[0]) & (times <= right_interval[1])]
+    mask = (times >= right_interval[0]) & (times <= right_interval[1])
     level_high = np.polyfit(times[mask],intergal_curve[mask],0)[0]
     d_high = np.sqrt(np.var(intergal_curve[mask] - level_high))
 


### PR DESCRIPTION
I could not calculate the T90 of a certain GBM trigger. From the traceback i found a _possible_ mistake: seems like there are extra brackets in masks: [Lines 49-53](https://github.com/Jorezzz/pygrb_lc/compare/main...mickolaua:pygrb_lc:fix-calc-t90?expand=1#diff-ce37d97fe2abaecb2a48133b436bd0d8adcdbd92e52d6c6750e867cb5c67bf28R49-R53).

<details>
  <summary>Example of traceback</summary>
  <code>
  ---------------------------------------------------------------------------
  IndexError                                Traceback (most recent call last)
  Cell In[96], line 1
  ----> 1 calculate_t_90(times, signal, *interval_t90)
  
  File ~/aware_dev/lib/python3.10/site-packages/pygrb_lc/light_curves/utils.py:50, in calculate_t_90(times, intergal_curve, left_interval, right_interval, plot)
       47 right_interval = right_interval if is_iterable(right_interval) else (right_interval,times[-1])
       49 mask = [(times >= left_interval[0]) & (times <= left_interval[1])]
  ---> 50 level_low = np.polyfit(times[mask],intergal_curve[mask],0)[0]
       51 d_low = np.sqrt(np.var(intergal_curve[mask] - level_low))
       53 mask = [(times >= right_interval[0]) & (times <= right_interval[1])]
  
  IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
  </code>
</details>